### PR TITLE
Update DeployTo.ts

### DIFF
--- a/src/DeployTo/DeployToV2/src/DeployTo.ts
+++ b/src/DeployTo/DeployToV2/src/DeployTo.ts
@@ -66,8 +66,8 @@ export async function run() {
         "-IncludeDb", IncludeDb
         ];
         if (ZeroDowntimeMode) {
-            args.push("-ZeroDowntimeMode");
-            args.push(ZeroDowntimeMode);
+            argsShow.push("-ZeroDowntimeMode");
+            argsShow.push(ZeroDowntimeMode);
         }
 
         logInfo(`${executable} ${argsShow.join(" ")}`);


### PR DESCRIPTION
ZeroDownTime Deployment causes issue: 

##[error]parameter because parameter 'ZeroDowntimeMode' is specified more than once. To provide multiple values to parameters 
that can accept multiple values, use the array syntax. For example, "-parameter value1,value2,value3".
At line:1 char:471
+ ... IncludeDb false -ZeroDowntimeMode ReadWrite -ZeroDowntimeMode ReadWri ...
+                                                 ~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidArgument: (:) [DeployTo.ps1], ParameterBindingException
    + FullyQualifiedErrorId : ParameterAlreadyBound,DeployTo.ps1